### PR TITLE
fix: escape apostrophes to resolve ESLint no-unescaped-entities warnings

### DIFF
--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -69,7 +69,8 @@ export const HeroSection = () => {
           </h1>
           <p className="mt-4 text-center text-white/60 md:text-lg">
             I specialize in transforming design into functional,
-            high-performance web application. Let's discuss your next project
+            high-performance web application. Let&apos;s discuss your next
+            project
           </p>
         </div>
         <div className="flex flex-col md:flex-row justify-center items-center mt-8 gap-4">
@@ -79,7 +80,7 @@ export const HeroSection = () => {
           </button>
           <button className="inline-flex items-center gap-2 border border-white bg-white text-gray-900 px-6 h-12 rounded-xl">
             <span>👋</span>
-            <span className="font-semibold">Let's Connect</span>
+            <span className="font-semibold">Let&apos;s Connect</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
- Replace unescaped apostrophes with &apos; in Hero section text
- Fix react/no-unescaped-entities ESLint rule violations